### PR TITLE
Fix warning C6387 in func resetRankData()

### DIFF
--- a/src/snake.c
+++ b/src/snake.c
@@ -531,6 +531,13 @@ void resetRankData()
 	if (pressed == 'y') // y값인 경우 (=사용자가 종료 선택) 
 	{
 		fopen_s(&fp, "highscores.txt", "w+");	//highscore.txt를 쓰기 모드로 열음
+		
+		if (fp == NULL)
+		{
+			printf("FAILED!!!");
+			waitForAnyKey();
+			return;
+		}
 
 		for (i = 0; i < 5; i++)
 		{


### PR DESCRIPTION
- Add check logic if 'fp' is NULL.
- If 'fp' is NULL, "FAILED!!!" message will be print and return to main menu.