### PR TITLE
Add func getNextLevelScore() and Change level-up check logic in func startGame.

### DIFF
--- a/src/snake.c
+++ b/src/snake.c
@@ -734,7 +734,7 @@ void startGame( int snakeXY[][SNAKE_ARRAY_SIZE], int foodXY[], int consoleWidth,
 	clock_t endWait; // 대기 종료 시간을 담을 변수.
 
 	int waitMili = CLOCKS_PER_SEC-(speed)*(CLOCKS_PER_SEC/10);	// 현재 게임 속도에 맞는 대기 시간 설정 (대기 시간 : 1초 - 게임속도(단계) * 0.1초)
-	int tempScore = 10*speed; // 속도 증가 시점에서 현재 스코어와 비교할 기준값을 위한 임시 변수. 초기값 : 10 * 속도.
+	int currentLevelScore = 10*speed; // 속도 증가 시점에서 현재 스코어와 비교할 기준값을 위한 임시 변수. 초기값 : 10 * 속도.
 	int oldDirection = 0; // 직전 방향값을 저장하기 위한 변수
 	int canChangeDirection = 1; // 방향 전환이 가능한 상태인지 저장 (0: 불가능, 1: 가능)
 
@@ -772,10 +772,10 @@ void startGame( int snakeXY[][SNAKE_ARRAY_SIZE], int foodXY[], int consoleWidth,
 				snakeLength++; //Snake의 길이 증가.
 				score+=speed; //현재 속도만큼 점수 부여.
 
-				if( score >= 10*speed+tempScore) // 현재 점수가 게임 속도 * 10 + 기준값이 되는 현재 단계 스코어보다 큰 경우 게임 속도 증가 처리.
+				if( score >= getNextLevelScore(speed, currentLevelScore)) // 현재 점수가 게임 속도 * 10 + 기준값이 되는 현재 단계 스코어보다 큰 경우 게임 속도 증가 처리.
 				{
 					speed++; // 게임 속도 증가.
-					tempScore = score; // 판단 기준값을 현재 스코어로 변경.
+					currentLevelScore = score; // 판단 기준값을 현재 스코어로 변경.
 
 					//게임 속도가 9 이하인 경우
 					if(speed <= 9) //TODO : 점검 필요

--- a/src/snake.c
+++ b/src/snake.c
@@ -2,18 +2,14 @@
 Author: Matthew Vlietstra
 Version: 0.5
 Date: 28/09/2010
-
 Discription:
 This is a console snake game that can (or should) work in linux & windows environments.
-
 Windows:
 Compile with borland
-
 Linux:
 Please note, tested under Ubuntu not sure if it works in other linux environments. I recommend compiling with borland under windows for best results.
 Compile with gcc in linux using the following command:
 gcc snake.c -lm -o snake.out
-
 Cygwin:
 Although this program may compile/ run in Cygwin it runs slowly.	
 				
@@ -1148,4 +1144,3 @@ int main()
 	
 	return(0);
 }
-

--- a/src/snake.c
+++ b/src/snake.c
@@ -2,14 +2,18 @@
 Author: Matthew Vlietstra
 Version: 0.5
 Date: 28/09/2010
+
 Discription:
 This is a console snake game that can (or should) work in linux & windows environments.
+
 Windows:
 Compile with borland
+
 Linux:
 Please note, tested under Ubuntu not sure if it works in other linux environments. I recommend compiling with borland under windows for best results.
 Compile with gcc in linux using the following command:
 gcc snake.c -lm -o snake.out
+
 Cygwin:
 Although this program may compile/ run in Cygwin it runs slowly.	
 				
@@ -723,7 +727,6 @@ int cutTail(int snakeXY[][SNAKE_ARRAY_SIZE], int snakeLength) {
 * @param int score : 초기 점수값
 * @param int speed : 초기 게임의 속도 (단계)
 **/
-//Todo /maybe-later: 코드 정리 필요.
 void startGame( int snakeXY[][SNAKE_ARRAY_SIZE], int foodXY[], int consoleWidth, int consoleHeight, int snakeLength, int direction, int score, int speed)
 {
 	int gameOver = 0; // gameOver 여부 체크 변수. (0: 게임 진행, 1: 게임 오버, 2: 승리)
@@ -1112,6 +1115,21 @@ int mainMenu(void)
 }
 
 /**
+ * 다음 레벨의 기준 포인트 값을 구하는 함수
+ *
+ * @params int speed : 현재 게임의 속도
+ * @params int currentLevelPoint : 현 레벨의 기준 포인트
+ *
+ * @return int basePoint : 다음 레벨의 기준 포인트
+ **/
+int getNextLevelScore(int speed, int currentLevelPoint)
+{
+	int basePoint = speed * 10 + currentLevelPoint;
+	
+	return basePoint;
+}
+
+/**
 * main함수.
 * 초기화면 출력 후, mainMenu()를 이용해 반환되는 값에 따라 각각 함수 실행
 *
@@ -1144,3 +1162,4 @@ int main()
 	
 	return(0);
 }
+

--- a/src/snake.h
+++ b/src/snake.h
@@ -167,5 +167,6 @@ void welcomeArt(void);
 void controls(void);
 void exitYN(void);
 int mainMenu(void);
+int getNextLevelScore(int speed, int currentLevelScore);
 
 #endif


### PR DESCRIPTION
- 다음 레벨의 기준값 (현재 속도 x 10 + 현재 레벨의 기준값)을 반환하는 함수를 추가했습니다.
- 기존 startGame 내 if문에 하드코딩되어있던 스코어 비교값을 (다음 레벨로 넘길지 체크)를 새로 추가한 함수의 리턴값을 사용하도록 변경했습니다.