### PR TITLE
Bug/linux

### DIFF
--- a/src/snake.c
+++ b/src/snake.c
@@ -224,6 +224,7 @@ void moveSnakeArray(int snakeXY[][SNAKE_ARRAY_SIZE], int snakeLength, int direct
 **/
 void CursorView(char show)
 {
+	#ifdef _WIN32
 	HANDLE hConsole;
 	CONSOLE_CURSOR_INFO ConsoleCursor;
 
@@ -233,6 +234,9 @@ void CursorView(char show)
 	ConsoleCursor.dwSize = 1; //커서사이즈
 
 	SetConsoleCursorInfo(hConsole, &ConsoleCursor);
+	#else
+	gotoxy(1,1);
+	#endif
 	return;
 }
 

--- a/src/snake.h
+++ b/src/snake.h
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <math.h>
 #include <stdlib.h>
+#include <ctype.h>
 
 #define SNAKE_ARRAY_SIZE 310
 
@@ -74,6 +75,18 @@ const char WALL = '#';
 const char FOOD = '*';
 const char BLANK = ' ';
 
+static inline void strcpy_s(char *dest, size_t destsz, const char *src){
+    strcpy(dest, src);
+}
+
+static inline FILE* fopen_s(FILE** pFile, const char *filename, const char *mode){
+    return *pFile = fopen(filename, mode);
+}
+
+static inline void gets_s(char *str, size_t n){
+    gets(str);
+}
+
 //Linux Functions - These functions emulate some functions from the windows only conio header file
 //Code: http://ubuntuforums.org/showthread.php?t=549023
 void gotoxy(int x, int y)
@@ -82,7 +95,7 @@ void gotoxy(int x, int y)
 }
 
 //http://cboard.cprogramming.com/c-programming/63166-kbhit-linux.html
-int kbhit(void)
+int _kbhit(void)
 {
 	struct termios oldt, newt;
 	int ch;
@@ -110,7 +123,7 @@ int kbhit(void)
 }
 
 //http://www.experts-exchange.com/Programming/Languages/C/Q_10119844.html - posted by jos
-char getch()
+char _getch()
 {
 	char c;
 	system("stty raw");

--- a/src/snake.h
+++ b/src/snake.h
@@ -8,6 +8,9 @@
 
 #define SNAKE_ARRAY_SIZE 310
 
+const int SIZE_STR = 128;
+const int SIZE_NAME = 20;
+
 #ifdef _WIN32
 //Windows Libraries
 #include <conio.h>
@@ -26,9 +29,6 @@ const char SNAKE_BODY = (char)48;
 const char WALL = (char)127;
 const char FOOD = (char)14;
 const char BLANK = ' ';
-
-const int SIZE_STR = 128;
-const int SIZE_NAME = 20;
 
 /**
 * 커서의 위치를 화면 왼쪽상단을 기준으로 x,y 만큼 이동
@@ -60,6 +60,7 @@ void clrscr()
 #include <termios.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <string.h>
 
 //Linux Constants
 


### PR DESCRIPTION
일부 함수 및 상수 추가, 변경 후 리눅스와 macOS 등 타 플랫폼에서 동작하지 않는 문제를 수정했습니다.
- STR_SIZE, NAME_SIZE : #ifndef _WIN32 밖으로 이동
- _s 붙은 함수 대응 : 인라인 함수 추가하여 기존 함수와 연결
- 일부 함수명 변경 : kbhit -> _kbhit 등
- string.h include 추가